### PR TITLE
Doi badge

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,7 +9,6 @@ message: >-
 type: software
 authors:
   - given-names: Quentin
-    name-particle: Quentin
     family-names: Groom
     email: quentin.groom@plantentuinmeise.be
     affiliation: Meise Botanic Garden
@@ -34,7 +33,7 @@ abstract: >-
   species.
 keywords:
   - ducks
-  - 'sexually dimorphic '
+  - sexually dimorphic
   - data cube
   - Global Biodiversity Information Facility
 license: MIT

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # fowlplay
+
+<!-- badges: start -->
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.12793619.svg)](https://doi.org/10.5281/zenodo.12793619)
+<!-- badges: end -->
+
 A notebook to explore the value of sex data buried in the Global Biodiversity Information Facility for ducks


### PR DESCRIPTION
This PR

- Add a DOI badge to the README, that points to the versionless DOI on Zenodo (i.e. always the most recent version)
- Makes some minor edits to the CITATION.cff